### PR TITLE
Fix: poppy_fnc_replaceGPS only removes "ItemGPS", not other Terminals (UAV etc.)

### DIFF
--- a/functions/atomics/fn_replaceGPS.sqf
+++ b/functions/atomics/fn_replaceGPS.sqf
@@ -2,7 +2,15 @@
 params ["_unit", "_array"];
 
 private _gps = selectRandom _array;
-_unit unlinkItem "ItemGPS";
+
+private _oldGps = assignedItems _unit select {
+    (_x isKindOf ["ItemGPS", configFile >> "CfgWeapons"])
+    or
+    (_x isKindOf ["UavTerminal_base", configFile >> "CfgWeapons"])
+};
+if count (count _oldGps > 0) then {
+    _unit unlinkItem (_oldGps select 0);
+};
 if (_gps != "") then {
     _unit linkItem _gps;
 };

--- a/functions/atomics/fn_replaceGPS.sqf
+++ b/functions/atomics/fn_replaceGPS.sqf
@@ -8,7 +8,7 @@ private _oldGps = assignedItems _unit select {
     or
     (_x isKindOf ["UavTerminal_base", configFile >> "CfgWeapons"])
 };
-if count (count _oldGps > 0) then {
+if (count _oldGps > 0) then {
     _unit unlinkItem (_oldGps select 0);
 };
 if (_gps != "") then {


### PR DESCRIPTION
Title says it all.