### PR TITLE
Fixed tab accidentally found when testing sqf validation tools

### DIFF
--- a/functions/atomics/fn_replaceInsignia.sqf
+++ b/functions/atomics/fn_replaceInsignia.sqf
@@ -15,7 +15,7 @@ if (isClass (missionConfigFile >> "CfgUnitInsignia" >> _insignia)) then {
 
 if !(isNull _config) then {
     {
-    	if (_x == "insignia") exitwith {
+        if (_x == "insignia") exitwith {
             _unit setObjectTextureGlobal [
                 _forEachIndex,
                 getText (_config >> "texture")


### PR DESCRIPTION
* Fixed tab in fn_replaceInsignia.sqf

```
ERROR: Tab detected at ../cScripts/Loadouts\script\functions\atomics\fn_replaceInsignia.sqf Line number: 18
```