### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ basic automatically generated loadouts from above and learn from them.
 The loadout config has the following base structure:
 ```
 class CfgLoadouts {
-    class Common<Blufor|Opfor|Independant|Civilian> {
+    class Common<Blufor|Opfor|Independent|Civilian> {
         uniform[] = {...};
         vest[] = {...};
         backpack[] = {...};
@@ -147,7 +147,7 @@ class CfgLoadouts {
         preLoadout = "";
         postLoadout = "";
     };
-    class <unit class name|unit variable name>: Common<Blufor|Opfor|Independant|Civilian> {
+    class <unit class name|unit variable name>: Common<Blufor|Opfor|Independent|Civilian> {
         ...
     };
 };
@@ -158,28 +158,28 @@ randomness - almost all config entries support randomness. This means if you
 you have multiple entries, Poppy will select one of them randomly.
 
 There are a few special entries:
-- **primary[]**  
-  Primary takes a special format to support attachments:  
-  `{"weapon", "attachment", "attachment", "attachment"}`  
+- **primary[]**
+  Primary takes a special format to support attachments:
+  `{"weapon", "attachment", "attachment", "attachment"}`
   Multiple of these subarrays are supported. You only need to fill this
   array with the attachment slots you use.
-- **secondary[]**  
+- **secondary[]**
   Same as *primary*.
-- **launcher[]**  
+- **launcher[]**
   Same as *primary*.
-- **magazines[]**  
+- **magazines[]**
   Magazines does not support randomness for obvious reasons. Additionally, you
-  can simplify your loadouts by using  
+  can simplify your loadouts by using
   `..., <magazine class name>, <amount of magazines>,...`.
-- **items[]**  
+- **items[]**
   Same as *magazines*.
-- **lrRadios[]**  
+- **lrRadios[]**
   This does also not support randomness. All radios within this array will be
   given to the unit.
-- **preLoadout**  
+- **preLoadout**
   Can contain code that will be compiled and called with the current unit and
   the loadout class before applying the loadout.
-- **postLoadout**  
+- **postLoadout**
   Same as *preLoadout*, but called after applying the loadout.
 
 ### Changing Poppy's settings
@@ -187,23 +187,23 @@ Poppy has a few settings that allow you little bit more customization. You can
 find them in the `CfgPoppy.hpp` file. You can easily change them by editing
 that file. Note that due to how configs work you will have to `0` to disable a
 setting and `1` to enable a setting.
-- **forceShowInfos**  
+- **forceShowInfos**
   Show info messages in multiplayer.
-- **forceShowWarnings**  
+- **forceShowWarnings**
   Show warning messages in multiplayer.
-- **forceShowErrors**  
+- **forceShowErrors**
   Show error messages in multiplayer.
-- **showLoadoutInBriefing**  
+- **showLoadoutInBriefing**
   Show the loadout of the player on the briefing screen.
-- **enableAILoadoutsSP**  
+- **enableAILoadoutsSP**
   Enables loadouts for playable AI units in singleplayer.
 
 If you're using ACRE, there's a few more settings you can change:
-- **distributeGroupLeaderRadios**  
+- **distributeGroupLeaderRadios**
   Enabling this will automatically give each group leader a long range radio.
-- **groupLeaderRadio**  
+- **groupLeaderRadio**
   This radio will be given to all group leaders if you enabled the setting
   above.
-- **channelNames[]**  
+- **channelNames[]**
   These are the channel names that will be assigned to the long range radio
   channels, in the given order. These channel names apply to all radio types.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ class CfgLoadouts {
         launcher[] = {...};
         insignia[] = {...};
         lrRadios[] = {...};
+        srRadio = "";
         preLoadout = "";
         postLoadout = "";
     };
@@ -176,6 +177,8 @@ There are a few special entries:
 - **lrRadios[]**
   This does also not support randomness. All radios within this array will be
   given to the unit.
+- **srRadio**
+  Only supports one radio given as string. If set to `""`, no radio will be given to the unit. Defaults to `"ItemRadio"` when using TFAR or `"ACRE_PRC343"` when using ACRE.
 - **preLoadout**
   Can contain code that will be compiled and called with the current unit and
   the loadout class before applying the loadout.

--- a/functions/atomics/fn_replaceGPS.sqf
+++ b/functions/atomics/fn_replaceGPS.sqf
@@ -2,7 +2,13 @@
 params ["_unit", "_array"];
 
 private _gps = selectRandom _array;
-_unit unlinkItem "ItemGPS";
+
+{
+    if ((_x isKindOf ["ItemGPS", configFile >> "CfgWeapons"]) or (_x isKindOf ["UavTerminal_base", configFile >> "CfgWeapons"])) exitWith {
+        _unit unlinkItem _x;
+    };
+} count (assignedItems _unit);
+
 if (_gps != "") then {
     _unit linkItem _gps;
 };

--- a/functions/atomics/fn_replaceItems.sqf
+++ b/functions/atomics/fn_replaceItems.sqf
@@ -8,20 +8,10 @@ private _arrayCount = count _array;
 for "_i" from 0 to (_arrayCount - 1) do {
     private _currentItem = _array select _i;
 
-    private _sorting = if (
-        GVAR(usesACE)
-        && {[_unit] call ACE_Medical_fnc_isMedic}
-        && {toLower _currentItem in ACE_MEDICAL_ITEMS}
-    ) then {
-        [BACKPACK, UNIFORM, VEST]
-    } else {
-        [UNIFORM, BACKPACK, VEST]
-    };
-
     // Check of next index is amount to add
     if ((_i + 1 < _arrayCount) && {(_array select (_i + 1)) isEqualType 0}) then {
         for "_j" from 1 to (_array select (_i + 1)) do {
-            [_unit, _currentItem, _sorting] call FUNC(addItemSorted);
+            [_unit, _currentItem] call FUNC(addItemSorted);
         };
         // Skip next index (the amount of added items)
         _i = _i + 1;
@@ -29,7 +19,7 @@ for "_i" from 0 to (_arrayCount - 1) do {
         if (_currentItem isKindOf ["ItemRadio", configFile >> "CfgWeapons"]) then {
             [_unit, _currentItem] call FUNC(replaceRadio);
         } else {
-            [_unit, _currentItem, _sorting] call FUNC(addItemSorted);
+            [_unit, _currentItem] call FUNC(addItemSorted);
         };
     };
 };

--- a/functions/atomics/fn_replaceMagazines.sqf
+++ b/functions/atomics/fn_replaceMagazines.sqf
@@ -19,7 +19,7 @@ for "_i" from 0 to (_arrayCount - 1) do {
 
         if (_itemCount > 0) then {
             for "_j" from 1 to _itemCount do {
-                [_unit, _currentItem, [VEST, BACKPACK, UNIFORM]] call FUNC(addItemSorted);
+                [_unit, _currentItem] call FUNC(addItemSorted);
             };
         };
 
@@ -29,7 +29,7 @@ for "_i" from 0 to (_arrayCount - 1) do {
         if (_loadableWeapon != "") then {
             _unit addWeaponItem [_loadableWeapon, _currentItem];
         } else {
-            [_unit, _currentItem, [VEST, BACKPACK, UNIFORM]] call FUNC(addItemSorted);
+            [_unit, _currentItem] call FUNC(addItemSorted);
         };
     };
 };

--- a/functions/atomics/fn_replaceRadio.sqf
+++ b/functions/atomics/fn_replaceRadio.sqf
@@ -10,4 +10,4 @@ switch (true) do {
     };
 };
 
-[_unit, _radio, [UNIFORM, BACKPACK, VEST]] call FUNC(addItemSorted);
+[_unit, _radio] call FUNC(addItemSorted);

--- a/functions/main/fn_addItemSorted.sqf
+++ b/functions/main/fn_addItemSorted.sqf
@@ -1,11 +1,11 @@
 #include "..\script_component.hpp"
-params ["_unit", "_item", "_sorting"];
+params ["_unit", "_item"];
 
 if !(_unit canAdd _item) exitWith {
     GVAR(overflowItems) pushBack _item;
 };
 
-private _containers = _sorting apply {_unit call _x};
+private _containers = [UNIFORM, VEST, BACKPACK] apply {_unit call _x};
 
 {
     if (_x canAdd _item) exitWith {

--- a/functions/main/fn_applyLoadout.sqf
+++ b/functions/main/fn_applyLoadout.sqf
@@ -6,6 +6,7 @@ private _config     = configNull;
 if (_loadConfig) then {
     _config = missionConfigFile >> "CfgLoadouts" >> _loadout;
     [_unit, _loadout] call compile (getText (_config >> "preLoadout"));
+    [QGVAR(preLoadout), [_unit, _loadout]] call CBA_fnc_localEvent;
 };
 
 private _uniqueRadio = [_unit] call FUNC(getUniqueRadio);
@@ -42,4 +43,5 @@ _unit selectWeapon (primaryWeapon _unit);
 
 if (_loadConfig) then {
     [_unit, _loadout] call compile (getText (_config >> "postLoadout"));
+    [QGVAR(postLoadout), [_unit, _loadout]] call CBA_fnc_localEvent;
 };

--- a/functions/main/fn_applyLoadout.sqf
+++ b/functions/main/fn_applyLoadout.sqf
@@ -9,7 +9,7 @@ if (_loadConfig) then {
     [QGVAR(preLoadout), [_unit, _loadout]] call CBA_fnc_localEvent;
 };
 
-private _uniqueRadio = [_unit] call FUNC(getUniqueRadio);
+private _uniqueRadio = [_unit, _config] call FUNC(getUniqueRadio);
 
 GVAR(overflowItems) = [];
 if (_loadConfig) then {

--- a/functions/main/fn_getSideConfig.sqf
+++ b/functions/main/fn_getSideConfig.sqf
@@ -4,7 +4,7 @@ params ["_side"];
 switch (_side) do {
     case west:        { "CommonBlufor" };
     case east:        { "CommonOpfor" };
-    case independent: { "CommonIndependant" };
+    case independent: { "CommonIndependent" };
     case civilian:    { "CommonCivilian" };
     default           { "CommonDefault" };
 };

--- a/functions/main/fn_getUniqueRadio.sqf
+++ b/functions/main/fn_getUniqueRadio.sqf
@@ -1,20 +1,28 @@
 #include "..\script_component.hpp"
 params ["_unit"];
 
+private _srRadio = if (isText (_config >> "srRadio")) then {
+    getText (_config >> "srRadio")
+} else {
+    if (GVAR(usesACRE)) then {"ACRE_PRC343"} else {"ItemRadio"};
+};
+
+if (_srRadio == "") exitWith {""};
+
 switch (true) do {
     case (GVAR(usesACRE)): {
         {
-            if (_x isKindOf ["ACRE_PRC343", configFile >> "CfgWeapons"]) exitWith {_x};
-            "ACRE_PRC343"
+            if (_x isKindOf [_srRadio, configFile >> "CfgWeapons"]) exitWith {_x};
+            _srRadio
         } forEach (items _unit);
     };
     case (GVAR(usesTFAR)): {
         {
-            if (_x isKindOf ["ItemRadio", configFile >> "CfgWeapons"]) exitWith {_x};
-            "ItemRadio"
+            if (_x isKindOf [_srRadio, configFile >> "CfgWeapons"]) exitWith {_x};
+            _srRadio
         } forEach (assignedItems _unit);
     };
     default {
-        "ItemRadio"
+        _srRadio
     };
 };


### PR DESCRIPTION
* All kinds of gps/terminal items will be replaced. Closes #19 
* CBA custom events `Poppy_preLoadout` and `Poppy_postLoadout` will be raised in `FUNC(applyLoadout)`. closes #22 
* Fix typo "independant" -> "independent"
* Allow defining a standard short range radio in CfgLoadouts (`srRadio = "yourradioclassname"`). Defaults to "ItemRadio" or "ACRE_PRC343". Also updated README.MD. closes #21 
* Always try to add items/magazines to the uniform first, then vest, then backpack. This may require some resorting by the player on mission start, but it prevents items not fitting into the containers that would fit when adding them in Arsenal.