### PR TITLE
Allow player variable to select loadout

### DIFF
--- a/functions/main/fn_applyLoadout.sqf
+++ b/functions/main/fn_applyLoadout.sqf
@@ -40,6 +40,9 @@ if (GVAR(usesACRE)) then {
 
 _unit selectWeapon (primaryWeapon _unit);
 
+// Save classname of selected loadout to variable.
+_unit setVariable [QGVAR(loadout), _loadout];
+
 if (_loadConfig) then {
     [_unit, _loadout] call compile (getText (_config >> "postLoadout"));
 };

--- a/functions/main/fn_selectLoadout.sqf
+++ b/functions/main/fn_selectLoadout.sqf
@@ -2,11 +2,18 @@
 params ["_unit"];
 
 private _config       = missionConfigFile >> "CfgLoadouts";
+private _variable     = _unit getVariable [QGVAR(Loadout), [""]];
 private _variableName = vehicleVarName _unit;
 private _className    = typeOf _unit;
 private _sideConfig   = [side group _unit] call FUNC(getSideConfig);
 
 switch (true) do {
+    case (isClass (_config >> _variable)): {
+        if !(_variable isKindOf [_sideConfig, _config]) then {
+            ["The loadout for """ + _variable + """ does not inherit from """ + _sideConfig + """."] call FUNC(logWarning);
+        };
+        _variable
+    };
     case (isClass (_config >> _variableName)): {
         if !(_variableName isKindOf [_sideConfig, _config]) then {
             ["The loadout for """ + _variableName + """ does not inherit from """ + _sideConfig + """."] call FUNC(logWarning);


### PR DESCRIPTION
This changes will store your spawned in loadout as a variable on a player and use this variable when selecting loadout.

This allow the player to change loadout using:
`[player, "My_Loadout"] call Poppy_fnc_applyLoadout;` and then respawn with that selected loadout.

The variable is saved as `Poppy_Loadout`